### PR TITLE
Allow URL bookmarks

### DIFF
--- a/bookmarker-menu.lua
+++ b/bookmarker-menu.lua
@@ -588,7 +588,7 @@ end
 function jumpToBookmark(slot)
   if bookmarkExists(slot) then
     local bookmark = bookmarks[slot]
-    if fileExists(bookmark["path"]) then
+    if string.sub(bookmark["path"], 1, 4) == "http" or fileExists(bookmark["path"]) then
       if parsePath(mp.get_property("path")) == bookmark["path"] then
         mp.set_property_number("time-pos", bookmark["pos"])
       else


### PR DESCRIPTION
It would be nice to be able to bookmark URLs opened with mpv's youtube-dl plugin or similar.

This patch skips fileExists() check for paths starting with 'http', when supplying them to loadfile, which allows bookmarks with an URL in the path to be opened.