### PR TITLE
Support for local bookmark tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ local confirmDelete = false
 local rate = 1.5
 -- The filename for the bookmarks file
 local bookmarkerName = "bookmarker.json"
+-- Use a bookmark table thats generated/used in the working directory instead of using a global table
+local localTable = false
 ```
 
 It's recommended not to touch `bookmarkerName` but it's there to be changed in case you already have a file called `bookmarker.json` and don't want that to be overwritten, or to change it to `bookmarks.json` to convert bookmarks created by [mpv-bookmarker](https://github.com/nimatrueway/mpv-bookmark-lua-script).
@@ -107,7 +109,7 @@ For example, `Awesome moment @ %t` will show up as `Awesome moment @ 00:13:41.67
 
 ## Testing
 
-This has been tested on Windows. In theory, it should also work for Unix systems, but it hasn't been tested on those.
+This has been tested on Windows and some testing done on Linux.  In theory, it should also work for macOS, but it hasn't been tested on it.
 
 ## Changelog
 

--- a/bookmarker-menu.lua
+++ b/bookmarker-menu.lua
@@ -17,6 +17,8 @@ local confirmDelete = false
 local rate = 1.5
 -- The filename for the bookmarks file
 local bookmarkerName = "bookmarker.json"
+-- Use a bookmark table thats generated/used in the working directory instead of using a global table
+local localTable = false
 
 -- All the "global" variables and utilities; don't touch these
 local utils = require 'mp.utils'
@@ -264,8 +266,8 @@ end
 function getFilepath(filename)
   if isWindows() then
   	return os.getenv("APPDATA"):gsub("\\", "/") .. "/mpv/" .. filename
-  else	
-	return os.getenv("HOME") .. "/.config/mpv/" .. filename
+  else
+    return os.getenv("HOME") .. "/.config/mpv/" .. filename
   end
 end
 
@@ -426,7 +428,11 @@ end
 -- Also checks for bookmarks made by "mpv-bookmarker" and converts them
 -- Also removes anything it doesn't recognize as a bookmark
 function loadBookmarks()
-  bookmarks = loadTable(getFilepath(bookmarkerName))
+  if localTable then
+    bookmarks = loadTable(parsePath(mp.get_property("working-directory") .. "/" .. bookmarkerName))
+  else
+    bookmarks = loadTable(getFilepath(bookmarkerName))
+  end
   if bookmarks == nil then bookmarks = {} end
 
   local doSave = false
@@ -476,7 +482,11 @@ end
 
 -- Save the globally loaded bookmarks to the JSON file
 function saveBookmarks()
-  saveTable(bookmarks, getFilepath(bookmarkerName))
+  if localTable then
+    saveTable(bookmarks, parsePath(mp.get_property("working-directory") .. "/" .. bookmarkerName))
+  else
+    saveTable(bookmarks, getFilepath(bookmarkerName))
+  end
 end
 
 -- Make a bookmark of the current media file, position and name

--- a/bookmarker-menu.lua
+++ b/bookmarker-menu.lua
@@ -488,7 +488,7 @@ function makeBookmark(bname)
     local bookmark = {
       name = parseName(bname),
       pos = mp.get_property_number("time-pos"),
-      path = parsePath(mp.get_property("path")),
+      path = parsePath(mp.get_property("working-directory") .. "/" .. mp.get_property("path")),
       version = 2
     }
     return bookmark


### PR DESCRIPTION
For my desired use of bookmarker I want the bookmark file to be saved and loaded in the working directory instead of mpv's folder. I created an option to set this functionality, but by default bookmarker uses the global table. When this option is set to false it behaves the same way as it did before. I tested this on Linux but it should still work on Windows. I might add the ability to toggle whether it is reading local or global bookmarks in mpv itself, but this seemed like a good spot to do a pull request.